### PR TITLE
13 us company ee creation

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -6,4 +6,8 @@ class EmployeesController < ApplicationController
   def show
     @employee = Employee.find(params[:id])
   end
+
+  def new
+    @company = Company.find(params[:id])
+  end
 end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -10,4 +10,17 @@ class EmployeesController < ApplicationController
   def new
     @company = Company.find(params[:id])
   end
+
+  def create
+    company = Company.find(params[:id])
+    company.employees.create(
+      first_name: params[:employee][:first_name],
+      last_name: params[:employee][:last_name],
+      i9_eligible: params[:employee][:i9_eligible],
+      benefits_eligible: params[:employee][:benefits_eligible],
+      salary: params[:employee][:salary]
+    )
+
+    redirect_to "/companies/#{company.id}/employees"
+  end
 end

--- a/app/views/companies/employees_index.html.erb
+++ b/app/views/companies/employees_index.html.erb
@@ -11,4 +11,4 @@
   <p>Salary: <%= employee.salary %></p>
 <% end %>
 
-<a href="/employees/new"><button>Add New Employee</button></a>
+<a href="/companies/<%= @company.id %>/employees/new"><button>Add New Employee</button></a>

--- a/app/views/companies/employees_index.html.erb
+++ b/app/views/companies/employees_index.html.erb
@@ -10,3 +10,5 @@
   <p>Benefits Eligible? <%= employee.benefits_eligible %></p>
   <p>Salary: <%= employee.salary %></p>
 <% end %>
+
+<a href="/employees/new"><button>Add New Employee</button></a>

--- a/app/views/employees/new.html.erb
+++ b/app/views/employees/new.html.erb
@@ -1,0 +1,22 @@
+<h1>Add New Employee for <%= @company.name %></h1>
+<form id="new_employee" action="/companies/<%= @company.id %>/employees" method="POST">
+  <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
+  <p>Enter Employee Details</p>
+  <label for="first_name">First Name</label>
+  <input type="text" name="employee[first_name]"><br/>
+  <label for="last_name">Last Name</label>
+  <input type="text" name="employee[last_name]"><br/>
+  <label for="i9_eligible?">i9 Eligible? </label>
+  <select name="employee[i9_eligible]">
+    <option value="true">True</option>
+    <option value="false">False</option>
+  </select><br/>
+   <label for="benefits_eligible?">Benefits Eligible?</label>
+  <select name="employee[benefits_eligible]">
+    <option value="true">True</option>
+    <option value="false">False</option>
+  </select><br/>
+  <label for="salary">Salary</label>
+  <input type="text" name="employee[salary]"><br/>
+  <input type="submit" value="Save Employee">
+</form>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,13 @@ Rails.application.routes.draw do
   get "/companies", to: "companies#index"
   get "/companies/new", to: "companies#new"
   post "/companies", to: "companies#create"
-  get "/companies/:id/employees", to: "companies#employees_index"
   get "/companies/:id", to: "companies#show"
   get "/companies/:id/edit", to: "companies#edit"
   patch "/companies/:id", to: "companies#update"
+  get "/companies/:id/employees", to: "companies#employees_index"
+  get "/companies/:id/employees/new", to: "employees#new"
+  post '/companies/:id/employees', to: "employees#create"
+  
   get "/employees", to: "employees#index"
   get "/employees/:id", to: "employees#show"
 end

--- a/spec/features/companies/employees_index_spec.rb
+++ b/spec/features/companies/employees_index_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe 'Show companys employees index', type: :feature do
         expect(page).to have_content(@latrice.salary)
         expect(page).to_not have_content(@jimbo)
       end
+
+      it "has a link to add a new employee for that company 'Create Employee'" do
+        expect(page).to  have_link('Add New Employee', href: "/employees/new")
+      end
     end
     # When I visit any page on the site
     # Then I see a link at the top of the page that takes me to the Child Index

--- a/spec/features/companies/employees_index_spec.rb
+++ b/spec/features/companies/employees_index_spec.rb
@@ -42,9 +42,16 @@ RSpec.describe 'Show companys employees index', type: :feature do
         expect(page).to have_content(@latrice.salary)
         expect(page).to_not have_content(@jimbo)
       end
+      
+      describe "link to create new employees that redirects to employees/new" do
+        it "has a link to add a new employee for that company 'Create Employee'" do
+          expect(page).to  have_link('Add New Employee', href: "/companies/#{@company.id}/employees/new")
+        end
 
-      it "has a link to add a new employee for that company 'Create Employee'" do
-        expect(page).to  have_link('Add New Employee', href: "/employees/new")
+        it "takes me to to '/companies/:id/employees/new' where I see a form to add a new employee" do
+          click_link "Add New Employee"
+          expect(page.current_path).to eq("/companies/#{@company.id}/employees/new")
+        end
       end
     end
     # When I visit any page on the site

--- a/spec/features/companies/show_spec.rb
+++ b/spec/features/companies/show_spec.rb
@@ -54,14 +54,5 @@ RSpec.describe 'Company Show Page', type: :feature do
         expect(page).to  have_link('All Companies', href: "/companies")
       end
     end
-
-    it "has a link to update the company 'Update Company'" do
-      expect(page).to  have_link('Edit Company', href: "/companies/#{@company.id}/edit")
-    end
-
-    it "when clicked, redirects to '/companies/:id/edit'" do
-      click_link("Edit Company")
-      expect(page).to have_current_path("/companies/#{@company.id}/edit")
-    end
   end
 end

--- a/spec/features/employees/new_spec.rb
+++ b/spec/features/employees/new_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe "'employee/new' page", type: :feature do
         end
         click_button('Save Employee') # submits the form
 
-        expect(page.current_path).to eq("companies/#{@company.id}/employees")
+        expect(page.current_path).to eq("/companies/#{@company.id}/employees")
         expect(page).to have_content("Trinity The Tuck")
-        expect(page).to have_content("i9 Eligible? True")
-        expect(page).to have_content("Benefits Eligible? False")
-        expect(page).to have_content("Salary 85000")
+        expect(page).to have_content("i-9 Eligible? true")
+        expect(page).to have_content("Benefits Eligible? false")
+        expect(page).to have_content("Salary: 85000")
       end
     end
   end

--- a/spec/features/employees/new_spec.rb
+++ b/spec/features/employees/new_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe "'employee/new' page", type: :feature do
+  before :each do
+    @company = Company.create!(name: "Frank and Roze", federal_ein: 123456789, non_profit: false, address_line_1: "4097 E 9th Ave", address_line_2: "", city: "Denver", state: "CO", zipcode: "80220")
+  end
+
+  describe 'When I am taken to employees/new' do
+    it 'has a form with fields for all the employee attributes' do
+      visit "/companies/#{@company.id}/employees/new"
+
+      expect(page).to have_content('First Name')
+      expect(page).to have_content('Last Name')
+      expect(page).to have_content('i9 Eligible?')
+      expect(page).to have_content('Benefits Eligible?')
+      expect(page).to have_content('Salary')
+    end
+
+    describe 'When I fill in the form and click Save Employee' do
+      it 'redirects to companies/:id/employees and has the new employee' do
+        visit "/companies/#{@company.id}/employees/new"
+
+        within("#new_employee") do
+          fill_in 'employee[first_name]', with: 'Trinity'
+          fill_in 'employee[last_name]', with: 'The Tuck'
+          select 'True', from: 'employee[i9_eligible]'
+          select 'False', from: 'employee[benefits_eligible]'
+          fill_in 'employee[salary]', with: 85000
+        end
+        click_button('Save Employee') # submits the form
+
+        expect(page.current_path).to eq("companies/#{@company.id}/employees")
+        expect(page).to have_content("Trinity The Tuck")
+        expect(page).to have_content("i9 Eligible? True")
+        expect(page).to have_content("Benefits Eligible? False")
+        expect(page).to have_content("Salary 85000")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds tests and MVC functionality needed for User Story 13, Parent Child Creation 

```
As a visitor
When I visit a Parent Children Index page
Then I see a link to add a new adoptable child for that parent "Create Child"
When I click the link
I am taken to '/parents/:parent_id/child_table_name/new' where I see a form to add a new adoptable child
When I fill in the form with the child's attributes:
And I click the button "Create Child"
Then a `POST` request is sent to '/parents/:parent_id/child_table_name',
a new child object/row is created for that parent,
and I am redirected to the Parent Childs Index page where I can see the new child listed
```