### PR TITLE
15 us ee true

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -1,6 +1,6 @@
 class EmployeesController < ApplicationController
   def index
-    @employees = Employee.all
+    @employees = Employee.all.where(i9_eligible: true)
   end
 
   def show

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -3,6 +3,7 @@
   <a href="/employees">All Employees</a> 
 </nav>
 <h1>All Employees</h1>
+<p><i>Note: Only i-9 eligible employees appear here.</i></p>
 <% @employees.each do |employee| %>
   <h3><%= employee.name %></h3>
   <p>i-9 Eligible? <%= employee.i9_eligible %></p>

--- a/spec/features/employees/index_spec.rb
+++ b/spec/features/employees/index_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Employees Index Page", type: :feature do
       @manila = Employee.create!(first_name: "Manila", last_name: "Luzon", i9_eligible: true, benefits_eligible: false, salary: 69000, company_id: @company.id)
       @latrice = Employee.create!(first_name: "Latrice", last_name: "Royale", i9_eligible: true, benefits_eligible: false, salary: 95000, company_id: @company.id)
       @jimbo = Employee.create!(first_name: "Jimbo", last_name: "Clown", i9_eligible: true, benefits_eligible: false, salary: 87340, company_id: @company2.id)
+      @monet = Employee.create!(first_name: "Money", last_name: "Exchange", i9_eligible: false, benefits_eligible: false, salary: 123000, company_id: @company2.id)
 
       visit "/employees"
     end
@@ -58,6 +59,15 @@ RSpec.describe "Employees Index Page", type: :feature do
 
       it "has a link at the top of the page that takes me to the Parent Index" do
         expect(page).to  have_link('All Companies', href: "/companies")
+      end
+    end
+
+    describe "only see records where the 'i-9 Eligible?' boolean column is `true`" do
+      it 'only shows i-9 eligible employees' do
+        expect(page).to have_content(@manila.name)
+        expect(page).to have_content(@latrice.name)
+        expect(page).to have_content(@jimbo.name)
+        expect(page).to_not have_content(@monet.name) # Employees not i-9 eligible
       end
     end
   end


### PR DESCRIPTION
This PR adds testing and functionality for User Story 15, Child Index only shows `true` Records 
```
As a visitor
When I visit the child index
Then I only see records where the boolean column is `true`
```