### PR TITLE
16 us alphabetical

### DIFF
--- a/app/controllers/company_employees_controller.rb
+++ b/app/controllers/company_employees_controller.rb
@@ -1,6 +1,10 @@
 class CompanyEmployeesController < ApplicationController
   def index
     @company = Company.find(params[:id])
-    @employees = Employee.where(company_id: @company.id)
+    if params[:sort] == "A-Z"
+      @employees = Employee.where(company_id: @company.id).order(first_name: :asc)
+    else
+      @employees = Employee.where(company_id: @company.id)
+    end
   end
 end

--- a/app/views/company_employees/index.html.erb
+++ b/app/views/company_employees/index.html.erb
@@ -3,7 +3,10 @@
   <a href="/employees">All Employees</a> 
 </nav>
 
+
 <h1><%= @company.name %> Employees</h1>
+<a href="/companies/<%= @company.id %>/employees?sort=A-Z">Sort Alphabetically</a>
+
 <% @employees.each do |employee| %>
   <h3><%= employee.name %></h3>
   <p>i-9 Eligible? <%= employee.i9_eligible.to_s.capitalize %></p>

--- a/spec/features/companies/employees/index_spec.rb
+++ b/spec/features/companies/employees/index_spec.rb
@@ -66,5 +66,19 @@ RSpec.describe 'Show companys employees index', type: :feature do
         expect(page).to  have_link('All Companies', href: "/companies")
       end
     end
+
+    describe "User Story 16 - Alphabetical order" do
+      it "has a link to sort the Company's Employees in alphabetical order" do
+        expect(page).to have_link("Sort Alphabetically", href: "/companies/#{@company.id}/employees?sort=A-Z")
+      end
+
+      it "when clicked, directs back to Employees Index Page with Employees in Alphabetical Order" do
+        expect(@manila.name).to appear_before(@latrice.name)
+        
+        click_link 'Sort Alphabetically'
+      
+        expect(@latrice.name).to appear_before(@manila.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds tests, and updates controller actions/ view for User Story 16, Sort Parent's Children in Alphabetical Order by name 
```
As a visitor
When I visit the Parent's children Index Page
Then I see a link to sort children in alphabetical order
When I click on the link
I'm taken back to the Parent's children Index Page where I see all of the parent's children in alphabetical order
```