### PR TITLE
17 18 us edit on indexes

### DIFF
--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -6,10 +6,11 @@
 <h1>Companies</h1>
 
 <% @companies.each do |company| %>
-  <p><b><a href="/companies/<%= company.id %>"><%= company.name %></a></b> 
-  <a id="edit_button" href="/companies/<%= company.id %>/edit"><button>Edit</button></a>
-  Created at: <%= company.created_at %>
-  </p>
+  <h3>
+    <b><a href="/companies/<%= company.id %>"><%= company.name %></a></b> 
+    <a id="edit_button" href="/companies/<%= company.id %>/edit"><button>Edit</button></a>
+    Created at: <%= company.created_at %>
+  </h3>
 <% end %>
 
 <a href="/companies/new"><button>Add New Company</button></a>

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -6,7 +6,10 @@
 <h1>Companies</h1>
 
 <% @companies.each do |company| %>
-  <h3><b><a href="/companies/<%= company.id %>"><%= company.name %></a></b> Created at: <%= company.created_at %></h3>
+  <p><b><a href="/companies/<%= company.id %>"><%= company.name %></a></b> 
+  <a id="edit_button" href="/companies/<%= company.id %>/edit"><button>Edit</button></a>
+  Created at: <%= company.created_at %>
+  </p>
 <% end %>
 
 <a href="/companies/new"><button>Add New Company</button></a>

--- a/app/views/company_employees/index.html.erb
+++ b/app/views/company_employees/index.html.erb
@@ -8,7 +8,10 @@
 <a href="/companies/<%= @company.id %>/employees?sort=A-Z">Sort Alphabetically</a>
 
 <% @employees.each do |employee| %>
-  <h3><%= employee.name %></h3>
+  <h3>
+    <%= employee.name %>
+    <a id="edit_button" href="/employees/<%= employee.id %>/edit"><button>Edit</button></a>
+  </h3>
   <p>i-9 Eligible? <%= employee.i9_eligible.to_s.capitalize %></p>
   <p>Benefits Eligible? <%= employee.benefits_eligible.to_s.capitalize %></p>
   <p>Salary: <%= employee.salary %></p>

--- a/app/views/employees/edit.html.erb
+++ b/app/views/employees/edit.html.erb
@@ -2,15 +2,15 @@
 
 <%= form_with id: "edit_employee", url: "/employees/#{@employee.id}", method: :patch, local: true do |form| %>
   <%= form.label :first_name, "First Name" %>
-  <%= form.text_field :first_name %>
+  <%= form.text_field :first_name, value: @employee.first_name %><br/>
   <%= form.label :last_name, "Last Name" %>
-  <%= form.text_field :last_name %>
+  <%= form.text_field :last_name, value: @employee.last_name %><br/>
   <%= form.label :i9_eligible, "i9 Eligible?" %>
-  <%= form.select :i9_eligible, [["True", "true"],["False", "false"]], selected: @employee.i9_eligible %>
+  <%= form.select :i9_eligible, [["True", "true"],["False", "false"]], selected: @employee.i9_eligible %><br/>
   <%= form.label :benefits_eligible, "Benefits Eligible?" %>
-  <%= form.select :benefits_eligible, [["True", "true"],["False", "false"]], selected: @employee.benefits_eligible %>
+  <%= form.select :benefits_eligible, [["True", "true"],["False", "false"]], selected: @employee.benefits_eligible %><br/>
   <%= form.label :salary, "Salary" %>
-  <%= form.number_field :salary %>
+  <%= form.number_field :salary, value: @employee.salary %><br/>
 
   <%= form.submit "Save Employee" %>
 <% end %>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -5,7 +5,10 @@
 <h1>All Employees</h1>
 <p><i>Note: Only i-9 eligible employees appear here.</i></p>
 <% @employees.each do |employee| %>
-  <h3><%= employee.name %></h3>
+  <h3>
+    <%= employee.name %>
+    <a id="edit_button" href="/employees/<%= employee.id %>/edit"><button>Edit</button></a>
+  </h3>
   <p>i-9 Eligible? <%= employee.i9_eligible %></p>
   <p>Benefits Eligible? <%= employee.benefits_eligible %></p>
   <p>Salary: <%= employee.salary %></p>

--- a/spec/features/companies/employees/index_spec.rb
+++ b/spec/features/companies/employees/index_spec.rb
@@ -80,5 +80,21 @@ RSpec.describe 'Show companys employees index', type: :feature do
         expect(@latrice.name).to appear_before(@manila.name)
       end
     end
+
+    describe "User story 18 Employee edit link for all Employees" do
+      it "has an edit link next to each employee's name" do
+        expect(page).to have_link("Edit", href: "/employees/#{@manila.id}/edit")
+        expect(page).to have_link("Edit", href: "/employees/#{@latrice.id}/edit")
+        expect(page).to_not have_link("Edit", href: "/employees/#{@jimbo.id}/edit") #works for different company
+      end
+    
+      it "When clicked, I can edit the employee's information" do
+        first('#edit_button').click
+
+        expect(current_path).to eq("/employees/#{@manila.id}/edit")
+        expect(current_path).to_not eq("/employees/#{@latrice.id}/edit")
+        expect(current_path).to_not eq("/employees/#{@jimbo.id}/edit")
+      end
+    end
   end
 end

--- a/spec/features/companies/index_spec.rb
+++ b/spec/features/companies/index_spec.rb
@@ -49,5 +49,19 @@ RSpec.describe 'Companies Index', type: :feature do
         end
       end
     end
+
+    describe "User story 17 company edit link for all companies" do
+      it "has an edit link next to each company's name" do
+        expect(page).to have_link("Edit", href: "/companies/#{@company1.id}/edit")
+        expect(page).to have_link("Edit", href: "/companies/#{@company2.id}/edit")
+        expect(page).to have_link("Edit", href: "/companies/#{@company3.id}/edit")
+      end
+    
+      it "When clicked, I can edit the company's information" do
+        first('#edit_button').click
+
+        expect(current_path). to eq("/companies/#{@company3.id}/edit")
+      end
+    end
   end
 end

--- a/spec/features/employees/index_spec.rb
+++ b/spec/features/employees/index_spec.rb
@@ -70,5 +70,21 @@ RSpec.describe "Employees Index Page", type: :feature do
         expect(page).to_not have_content(@monet.name) # Employees not i-9 eligible
       end
     end
+
+    describe "User story 18 Employee edit link for all Employees" do
+      it "has an edit link next to each employee's name" do
+        expect(page).to have_link("Edit", href: "/employees/#{@manila.id}/edit")
+        expect(page).to have_link("Edit", href: "/employees/#{@latrice.id}/edit")
+        expect(page).to have_link("Edit", href: "/employees/#{@jimbo.id}/edit")
+      end
+    
+      it "When clicked, I can edit the company's information" do
+        first('#edit_button').click
+
+        expect(current_path).to eq("/employees/#{@manila.id}/edit")
+        expect(current_path).to_not eq("/employees/#{@latrice.id}/edit")
+        expect(current_path).to_not eq("/employees/#{@jimbo.id}/edit")
+      end
+    end
   end
 end

--- a/spec/features/employees/index_spec.rb
+++ b/spec/features/employees/index_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Employees Index Page", type: :feature do
         expect(page).to have_link("Edit", href: "/employees/#{@jimbo.id}/edit")
       end
     
-      it "When clicked, I can edit the company's information" do
+      it "When clicked, I can edit the employee's information" do
         first('#edit_button').click
 
         expect(current_path).to eq("/employees/#{@manila.id}/edit")


### PR DESCRIPTION
This PR completes testing and view functionalities for two user stories:
```
User Story 17, Parent Update From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to edit that parent's info
When I click the link
I should be taken to that parent's edit page where I can update its information just like in User Story 12
```
```
User Story 18, Child Update From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to edit that child's info
When I click the link
I should be taken to that `ch
```