### PR TITLE
20 us employee delete

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -40,4 +40,11 @@ class EmployeesController < ApplicationController
     employee.save
     redirect_to "/employees/#{employee.id}"
   end
+
+  def destroy
+    employee = Employee.find(params[:id])
+    employee.delete
+
+    redirect_to "/employees"
+  end
 end

--- a/app/views/employees/show.html.erb
+++ b/app/views/employees/show.html.erb
@@ -4,7 +4,9 @@
 </nav>
 
 <h1><%= @employee.name %></h1>
-<a href="/employees/<%= @employee.id %>/edit"><button>Edit Employee</button></a></p>
+<%= button_to "Edit Employee", "/employees/#{@employee.id}/edit", method: :get %>
+<%= button_to "Delete Employee", "/employees/#{@employee.id}", method: :delete %>
+
 <p><b>i-9 Eligible?</b> <%= @employee.i9_eligible.to_s.capitalize %></p>
 <p><b>Benefits Eligible?</b> <%= @employee.benefits_eligible.to_s.capitalize %></p>
 <p><b>Salary:</b> <%= @employee.salary %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,5 @@ Rails.application.routes.draw do
   get "/employees/:id", to: "employees#show"
   get "/employees/:id/edit", to: "employees#edit"
   patch "/employees/:id", to: "employees#update"
+  delete "/employees/:id", to: "employees#destroy"
 end

--- a/spec/features/employees/delete_spec.rb
+++ b/spec/features/employees/delete_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Deleting an employee", type: :feature do
+  before :each do
+    @company = Company.create!(name: "Frank & Roze", federal_ein: 123456789, non_profit: false, address_line_1: "4097 E 9th Ave", address_line_2: "", city: "Denver", state: "CO", zipcode: "80220")
+    @manila = Employee.create!(first_name: "Manila", last_name: "Luzon", i9_eligible: true, benefits_eligible: false, salary: 69000, company_id: @company.id)
+    @latrice = Employee.create!(first_name: "Latrice", last_name: "Royale", i9_eligible: true, benefits_eligible: false, salary: 95000, company_id: @company.id)
+    @jimbo = Employee.create!(first_name: "Jimbo", last_name: "Clown", i9_eligible: true, benefits_eligible: false, salary: 87340, company_id: @company.id)
+    visit "/employees/#{@manila.id}"
+  end
+
+  describe 'User story 20 - has a link to delete employee, deletes the record, and redirects' do
+    it 'has a button to delete the employee' do
+      expect(page).to have_button('Delete Employee')
+    end
+
+    # When I click the link
+    # Then a 'DELETE' request is sent to '/child_table_name/:id',
+    # the child is deleted,
+    # and I am redirected to the child index page where I no longer see this child
+    it "deletes the employee when I click the button, and redirects to the Employees index page" do
+      expect(page).to have_content(@manila.name)
+      
+      click_button("Delete Employee")
+
+      expect(current_path).to eq("/employees")
+      expect(page).to_not have_content(@manila.name)
+      expect(page).to have_content(@latrice.name)
+      expect(page).to have_content(@jimbo.name)
+    end
+  end
+end

--- a/spec/features/employees/show_spec.rb
+++ b/spec/features/employees/show_spec.rb
@@ -54,5 +54,11 @@ RSpec.describe 'Employee Show Page', type: :feature do
         expect(page).to  have_link('Edit Employee', href: "/employees/#{@manila.id}/edit")
       end
     end
+
+    describe 'User story 20 - has a link to delete the employee "Delete employee"' do
+      it 'has a button to delete the employee' do
+        expect(page).to have_button('Delete Employee')
+      end
+    end
   end
 end

--- a/spec/features/employees/show_spec.rb
+++ b/spec/features/employees/show_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Employee Show Page', type: :feature do
 
     describe "I see a link to update that Employee 'Update Employee'" do
       it 'has a link to Update Employee (Edit)' do
-        expect(page).to  have_link('Edit Employee', href: "/employees/#{@manila.id}/edit")
+        expect(page).to  have_button('Edit Employee')
       end
     end
 


### PR DESCRIPTION
This PR completes tests and functionality for the feature: User Story 20, Child Delete 
```
As a visitor
When I visit a child show page
Then I see a link to delete the child "Delete Child"
When I click the link
Then a 'DELETE' request is sent to '/child_table_name/:id',
the child is deleted,
and I am redirected to the child index page where I no longer see this child
```