### PR TITLE
21 us record over threshold

### DIFF
--- a/app/controllers/company_employees_controller.rb
+++ b/app/controllers/company_employees_controller.rb
@@ -1,10 +1,13 @@
 class CompanyEmployeesController < ApplicationController
   def index
     @company = Company.find(params[:id])
+    # require 'pry'; binding.pry
     if params[:sort] == "A-Z"
-      @employees = Employee.where(company_id: @company.id).order(first_name: :asc)
+      @employees = @company.alphabetical_employees
+    elsif !params[:number].nil?
+      @employees = @company.salary_more_than(params[:number])
     else
-      @employees = Employee.where(company_id: @company.id)
+      @employees = @company.employees
     end
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -4,4 +4,12 @@ class Company < ApplicationRecord
   def employee_count
     self.employees.count
   end
+
+  def alphabetical_employees
+    self.employees.order(first_name: :asc)
+  end
+
+  def salary_more_than(amount)
+    self.employees.where("salary > #{amount.to_i}")
+  end
 end

--- a/app/views/company_employees/index.html.erb
+++ b/app/views/company_employees/index.html.erb
@@ -5,7 +5,13 @@
 
 
 <h1><%= @company.name %> Employees</h1>
-<a href="/companies/<%= @company.id %>/employees?sort=A-Z">Sort Alphabetically</a>
+<%= link_to "Sort Alphabetically", "/companies/#{@company.id}/employees?sort=A-Z" %>
+
+<%= form_with id: "filter_salary", url: "/companies/#{@company.id}/employees?number", method: :get, local: true do |form| %>
+  <%= form.label :number, "Show employees with salaries higher than:" %>
+  <%= form.number_field :number %>
+  <%= form.submit "Filter Employees" %>
+<% end %>
 
 <% @employees.each do |employee| %>
   <h3>

--- a/spec/features/companies/employees/index_spec.rb
+++ b/spec/features/companies/employees/index_spec.rb
@@ -96,5 +96,26 @@ RSpec.describe 'Show companys employees index', type: :feature do
         expect(current_path).to_not eq("/employees/#{@jimbo.id}/edit")
       end
     end
+
+    describe "User Story 21, Display Records Over a Given Threshold" do
+      it 'has a form that allows input of number value' do
+        expect(page).to have_css("#filter_salary")
+      end
+
+      it 'has a submit button for the form' do
+        expect(page).to have_button("Filter Employees")
+      end
+
+      it 'redirects to same page with filtered records after being filled out' do
+        within("#filter_salary") do
+          fill_in :number, with: 70000
+        end
+        click_button('Filter Employees') # submits the form
+  
+        expect(page.current_path).to eq("/companies/#{@company.id}/employees")
+        expect(page).to_not have_content(@manila.name) #salary below the threshold
+        expect(page).to have_content(@latrice.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds tests and functionality for User Story 21, Display Records Over a Given Threshold 

```
As a visitor
When I visit the Parent's children Index Page
I see a form that allows me to input a number value
When I input a number value and click the submit button that reads 'Only return records with more than `number` of `column_name`'
Then I am brought back to the current index page with only the records that meet that threshold shown.
```