### PR TITLE
22 23 us delete buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,367 +20,109 @@ This is a Ruby on Rails application that provides functionality to manage compan
 
 --------
 ## User Stories - Features
-
-A user story is a concise description of functionality that a specific user should experience while using your application. In these stories, we will refer to the "one" side of the relationship as the "parent" and the "many" side of the relationship as the "children/child". In the Pets/Shelters example, Shelter would be the parent, and Pets would be the children.
-
-Children can be associated to the Parent. Children belong to a parent. Anywhere you see `child_table_name` think `pets` from our Pets and Shelters example.
-
-Each user story will focus on one of the following:
-
-* __ActiveRecord__
-* __CRUD Functionality__
-* __Usability__: Users should be able to use the site easily. This means making sure there are links/buttons to reach all parts of the site and the styling/layout is sensible.
-
-_Note_: When writing code for each user story, it is important to go in **numerical** order; don't jump around. You may notice some later user stories "overwriting" earlier stories - this is intentional and mimics what you may experience on the job when working with real clients. 
-
-## Iteration 1
+### Iteration 1
 
 ##### CRUD
 
 ```
 [x] done
+User Story 1, Company Index 
 
-User Story 1, Parent Index 
+[x] done
+User Story 2, Company Show 
 
-For each parent table
-As a visitor
-When I visit '/parents'
-Then I see the name of each parent record in the system
+[x] done
+User Story 3, Employee Index 
+
+[x] done
+User Story 4, Employee Show 
+
+[x] done
+User Story 5, Company Employee Index 
+
+[x] done
+User Story 6, Company Index sorted by Most Recently Created 
+
+[x] done
+User Story 7, Company Employee Count
 ```
+
+##### Usability
 
 ```
 [x] done
+User Story 8, Employee Index Link
 
-User Story 2, Parent Show 
+[x] done
+User Story 9, Company Index Link
 
-As a visitor
-When I visit '/parents/:id'
-Then I see the parent with that id including the parent's attributes
-(data from each column that is on the parent table)
-```
-
-```
-[ ] done
-
-User Story 3, Child Index 
-
-As a visitor
-When I visit '/child_table_name'
-Then I see each Child in the system including the Child's attributes
-(data from each column that is on the child table)
-```
-
-```
-[ ] done
-
-User Story 4, Child Show 
-
-As a visitor
-When I visit '/child_table_name/:id'
-Then I see the child with that id including the child's attributes
-(data from each column that is on the child table)
-```
-
-```
-[ ] done
-
-User Story 5, Parent Children Index 
-
-As a visitor
-When I visit '/parents/:parent_id/child_table_name'
-Then I see each Child that is associated with that Parent with each Child's attributes
-(data from each column that is on the child table)
-```
-
-##### ActiveRecord
-
-```
-[ ] done
-
-User Story 6, Parent Index sorted by Most Recently Created 
-
-As a visitor
-When I visit the parent index,
-I see that records are ordered by most recently created first
-And next to each of the records I see when it was created
-```
-
-```
-[ ] done
-
-User Story 7, Parent Child Count
-
-As a visitor
-When I visit a parent's show page
-I see a count of the number of children associated with this parent
-```
-
-##### Usability
-
-```
-[ ] done
-
-User Story 8, Child Index Link
-
-As a visitor
-When I visit any page on the site
-Then I see a link at the top of the page that takes me to the Child Index
-```
-
-```
-[ ] done
-
-User Story 9, Parent Index Link
-
-As a visitor
-When I visit any page on the site
-Then I see a link at the top of the page that takes me to the Parent Index
-```
-
-```
-[ ] done
-
-User Story 10, Parent Child Index Link
-
-As a visitor
-When I visit a parent show page ('/parents/:id')
-Then I see a link to take me to that parent's `child_table_name` page ('/parents/:id/child_table_name')
+[x] done
+User Story 10, Company Employee Index Link
 ```
 
 ---
 
-## Iteration 2
+### Iteration 2
 
 ##### CRUD
 
 ```
-[ ] done
+[x] done
+User Story 11, Company Creation 
 
-User Story 11, Parent Creation 
+[x] done
+User Story 12, Company Update 
 
-As a visitor
-When I visit the Parent Index page
-Then I see a link to create a new Parent record, "New Parent"
-When I click this link
-Then I am taken to '/parents/new' where I  see a form for a new parent record
-When I fill out the form with a new parent's attributes:
-And I click the button "Create Parent" to submit the form
-Then a `POST` request is sent to the '/parents' route,
-a new parent record is created,
-and I am redirected to the Parent Index page where I see the new Parent displayed.
+[x] done
+User Story 13, Company Employee Creation 
+
+[x] done
+User Story 14, Employee Update 
+
+[x] done
+User Story 15, Employee Index only shows `true` Records 
+
+[x] done
+User Story 16, Sort Company's employees in Alphabetical Order by name 
 ```
-
-
-```
-[ ] done
-
-User Story 12, Parent Update 
-
-As a visitor
-When I visit a parent show page
-Then I see a link to update the parent "Update Parent"
-When I click the link "Update Parent"
-Then I am taken to '/parents/:id/edit' where I  see a form to edit the parent's attributes:
-When I fill out the form with updated information
-And I click the button to submit the form
-Then a `PATCH` request is sent to '/parents/:id',
-the parent's info is updated,
-and I am redirected to the Parent's Show page where I see the parent's updated info
-```
-
-```
-[ ] done
-
-User Story 13, Parent Child Creation 
-
-As a visitor
-When I visit a Parent Children Index page
-Then I see a link to add a new adoptable child for that parent "Create Child"
-When I click the link
-I am taken to '/parents/:parent_id/child_table_name/new' where I see a form to add a new adoptable child
-When I fill in the form with the child's attributes:
-And I click the button "Create Child"
-Then a `POST` request is sent to '/parents/:parent_id/child_table_name',
-a new child object/row is created for that parent,
-and I am redirected to the Parent Childs Index page where I can see the new child listed
-```
-
-```
-[ ] done
-
-User Story 14, Child Update 
-
-As a visitor
-When I visit a Child Show page
-Then I see a link to update that Child "Update Child"
-When I click the link
-I am taken to '/child_table_name/:id/edit' where I see a form to edit the child's attributes:
-When I click the button to submit the form "Update Child"
-Then a `PATCH` request is sent to '/child_table_name/:id',
-the child's data is updated,
-and I am redirected to the Child Show page where I see the Child's updated information
-```
-
-##### ActiveRecord
-
-```
-[ ] done
-
-User Story 15, Child Index only shows `true` Records 
-
-As a visitor
-When I visit the child index
-Then I only see records where the boolean column is `true`
-```
-
-```
-[ ] done
-
-User Story 16, Sort Parent's Children in Alphabetical Order by name 
-
-As a visitor
-When I visit the Parent's children Index Page
-Then I see a link to sort children in alphabetical order
-When I click on the link
-I'm taken back to the Parent's children Index Page where I see all of the parent's children in alphabetical order
-```
-
 ##### Usability
 
 ```
-[ ] done
+[x] done
+User Story 17, Company Update From Company Index Page 
 
-User Story 17, Parent Update From Parent Index Page 
-
-As a visitor
-When I visit the parent index page
-Next to every parent, I see a link to edit that parent's info
-When I click the link
-I should be taken to that parent's edit page where I can update its information just like in User Story 12
-```
-
-```
-[ ] done
-
-User Story 18, Child Update From Childs Index Page 
-
-As a visitor
-When I visit the `child_table_name` index page or a parent `child_table_name` index page
-Next to every child, I see a link to edit that child's info
-When I click the link
-I should be taken to that `child_table_name` edit page where I can update its information just like in User Story 14
+[x] done
+User Story 18, employee Update From employees Index Page 
 ```
 
 ---
 
-## Iteration 3
+### Iteration 3
 
 ##### CRUD
 
 ```
-[ ] done
-
+[x] done
 User Story 19, Parent Delete 
 
-As a visitor
-When I visit a parent show page
-Then I see a link to delete the parent
-When I click the link "Delete Parent"
-Then a 'DELETE' request is sent to '/parents/:id',
-the parent is deleted, and all child records are deleted
-and I am redirected to the parent index page where I no longer see this parent
-```
-
-```
-[ ] done
-
+[x] done
 User Story 20, Child Delete 
-
-As a visitor
-When I visit a child show page
-Then I see a link to delete the child "Delete Child"
-When I click the link
-Then a 'DELETE' request is sent to '/child_table_name/:id',
-the child is deleted,
-and I am redirected to the child index page where I no longer see this child
 ```
 
 ##### ActiveRecord
 
 ```
-[ ] done
-
+[x] done
 User Story 21, Display Records Over a Given Threshold 
-
-As a visitor
-When I visit the Parent's children Index Page
-I see a form that allows me to input a number value
-When I input a number value and click the submit button that reads 'Only return records with more than `number` of `column_name`'
-Then I am brought back to the current index page with only the records that meet that threshold shown.
 ```
 
 ##### Usability
 
 ```
-[ ] done
-
+[x] done
 User Story 22, Parent Delete From Parent Index Page 
 
-As a visitor
-When I visit the parent index page
-Next to every parent, I see a link to delete that parent
-When I click the link
-I am returned to the Parent Index Page where I no longer see that parent
-```
-
-```
-[ ] done
-
+[x] done
 User Story 23, Child Delete From Childs Index Page 
-
-As a visitor
-When I visit the `child_table_name` index page or a parent `child_table_name` index page
-Next to every child, I see a link to delete that child
-When I click the link
-I should be taken to the `child_table_name` index page where I no longer see that child
 ```
 ---
-
-## Extensions
-
-```
-[ ] done
-
-Extension 1: Sort Parents by Number of Children 
-
-As a visitor
-When I visit the Parents Index Page
-Then I see a link to sort parents by the number of `child_table_name` they have
-When I click on the link
-I'm taken back to the Parent Index Page where I see all of the parents in order of their count of `child_table_name` (highest to lowest) And, I see the number of children next to each parent name
-```
-
-```
-[ ] done
-
-Extension 2: Search by name (exact match)
-
-As a visitor
-When I visit an index page ('/parents') or ('/child_table_name')
-Then I see a text box to filter results by keyword
-When I type in a keyword that is an exact match of one or more of my records and press the Search button
-Then I only see records that are an exact match returned on the page
-```
-
-```
-[ ] done
-
-Extension 3: Search by name (partial match)
-
-As a visitor
-When I visit an index page ('/parents') or ('/child_table_name')
-Then I see a text box to filter results by keyword
-When I type in a keyword that is an partial match of one or more of my records and press the Search button
-Then I only see records that are an partial match returned on the page
-
-This functionality should be separate from your exact match functionality.

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -6,11 +6,12 @@
 <h1>Companies</h1>
 
 <% @companies.each do |company| %>
-  <h3>
-    <b><a href="/companies/<%= company.id %>"><%= company.name %></a></b> 
-    <a id="edit_button" href="/companies/<%= company.id %>/edit"><button>Edit</button></a>
+  <h3><%= link_to "#{company.name}", "/companies/#{company.id}" %></h3>
+  <p>
+    <%= button_to "Edit", "/companies/#{company.id}/edit", method: :get, id: "edit_button" %>
+    <%= button_to "Delete", "/companies/#{company.id}", method: :delete, id: "delete_button" %>
     Created at: <%= company.created_at %>
-  </h3>
+  </p>
 <% end %>
 
 <a href="/companies/new"><button>Add New Company</button></a>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -7,7 +7,8 @@
 <% @employees.each do |employee| %>
   <h3>
     <%= employee.name %>
-    <a id="edit_button" href="/employees/<%= employee.id %>/edit"><button>Edit</button></a>
+    <%= button_to "Edit", "/employees/#{employee.id}/edit", method: :get, id: "edit_button" %> 
+    <%= button_to "Delete", "/employees/#{employee.id}", method: :delete, id: "delete_button" %> 
   </h3>
   <p>i-9 Eligible? <%= employee.i9_eligible %></p>
   <p>Benefits Eligible? <%= employee.benefits_eligible %></p>

--- a/spec/features/companies/index_spec.rb
+++ b/spec/features/companies/index_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe 'Companies Index', type: :feature do
       expect(page).to have_content(@company3.name)
 
       first('#delete_button').click
+      
       expect(page).to have_content(@company1.name)
       expect(page).to have_content(@company2.name)
       expect(page).to_not have_content(@company3.name)

--- a/spec/features/companies/index_spec.rb
+++ b/spec/features/companies/index_spec.rb
@@ -52,15 +52,30 @@ RSpec.describe 'Companies Index', type: :feature do
 
     describe "User story 17 company edit link for all companies" do
       it "has an edit link next to each company's name" do
-        expect(page).to have_link("Edit", href: "/companies/#{@company1.id}/edit")
-        expect(page).to have_link("Edit", href: "/companies/#{@company2.id}/edit")
-        expect(page).to have_link("Edit", href: "/companies/#{@company3.id}/edit")
+        expect(page).to have_button("Edit")
       end
     
       it "When clicked, I can edit the company's information" do
         first('#edit_button').click
 
         expect(current_path). to eq("/companies/#{@company3.id}/edit")
+      end
+    end
+
+    describe "Delete button for all companies" do
+      it "has a Delete button next to every company name" do
+        expect(page).to have_button("Delete")
+      end
+
+      it "when clicked, will remove the company from the page" do
+      expect(page).to have_content(@company1.name)
+      expect(page).to have_content(@company2.name)
+      expect(page).to have_content(@company3.name)
+
+      first('#delete_button').click
+      expect(page).to have_content(@company1.name)
+      expect(page).to have_content(@company2.name)
+      expect(page).to_not have_content(@company3.name)
       end
     end
   end

--- a/spec/features/employees/index_spec.rb
+++ b/spec/features/employees/index_spec.rb
@@ -73,9 +73,7 @@ RSpec.describe "Employees Index Page", type: :feature do
 
     describe "User story 18 Employee edit link for all Employees" do
       it "has an edit link next to each employee's name" do
-        expect(page).to have_link("Edit", href: "/employees/#{@manila.id}/edit")
-        expect(page).to have_link("Edit", href: "/employees/#{@latrice.id}/edit")
-        expect(page).to have_link("Edit", href: "/employees/#{@jimbo.id}/edit")
+        expect(page).to have_button("Edit")
       end
     
       it "When clicked, I can edit the employee's information" do
@@ -84,6 +82,24 @@ RSpec.describe "Employees Index Page", type: :feature do
         expect(current_path).to eq("/employees/#{@manila.id}/edit")
         expect(current_path).to_not eq("/employees/#{@latrice.id}/edit")
         expect(current_path).to_not eq("/employees/#{@jimbo.id}/edit")
+      end
+    end
+
+    describe "Delete button for all employees" do
+      it "has a Delete button next to every employee name" do
+        expect(page).to have_button("Delete")
+      end
+
+      it "when clicked, will remove the employee from the page" do
+        expect(page).to have_content(@manila.name)
+        expect(page).to have_content(@latrice.name)
+        expect(page).to have_content(@jimbo.name)
+
+        first('#delete_button').click
+
+        expect(page).to_not have_content(@manila.name)
+        expect(page).to have_content(@latrice.name)
+        expect(page).to have_content(@jimbo.name)
       end
     end
   end


### PR DESCRIPTION
This PR adds tests and views for the following user stories:
```
User Story 22, Parent Delete From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to delete that parent
When I click the link
I am returned to the Parent Index Page where I no longer see that parent
```
```
User Story 23, Child Delete From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to delete that child
When I click the link
I should be taken to the `child_table_name` index page where I no longer see that child
```